### PR TITLE
Fixed command to run azure function

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You'll need to have all the same values listed above entered into Configuration 
 ## Usage
 Run it locally with this command:
 
-```func run```
+```func start```
 
 You can test functionality using the swagger UI, which will default to: http://localhost:7071/api/swagger/ui
 


### PR DESCRIPTION
I'm not sure why I had func run in the first place. Must have been a typo on my part.

The correct command is func start.